### PR TITLE
Fix: Prevent intellihide from hiding dock while hovered

### DIFF
--- a/dock-ng@ochi12.github.com/dockNG.js
+++ b/dock-ng@ochi12.github.com/dockNG.js
@@ -335,7 +335,11 @@ export const DockNG = GObject.registerClass({
 
     blockAutoHide(block) {
         this._blockAutoHide = block;
-        this.showDock(this._blockAutoHide && !Main.overview.visible);
+        if (!this._dashContainer.get_hover())
+            this.showDock(block && !Main.overview.visible);
+        else
+            this.showDock(!Main.overview.visible);
+
         this._onHover();
     }
 

--- a/dock-ng@ochi12.github.com/extension.js
+++ b/dock-ng@ochi12.github.com/extension.js
@@ -15,34 +15,18 @@
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
-
 import {Extension} from 'resource:///org/gnome/shell/extensions/extension.js';
 import {DockNGManager} from './dockManager.js';
 
 export default class ShelledDesktopIconExtension extends Extension {
-    constructor(metadata) {
-        super(metadata);
-
-        this._manager = null;
+    enable() {
+        this._manager = new DockNGManager(this);
     }
 
-    _addManager() {
-        if (this._manager === null)
-            this._manager = new DockNGManager(this);
-    }
-
-    _removeManager() {
+    disable() {
         if (this._manager) {
             this._manager.destroy();
             this._manager = null;
         }
-    }
-
-    enable() {
-        this._addManager();
-    }
-
-    disable() {
-        this._removeManager();
     }
 }


### PR DESCRIPTION
When opening an app that can overlap dock it is hovered, intellihide is still triggered. 