### PR TITLE
Persistent Dock Visibility and Optimized Transition On Overview Exit

### DIFF
--- a/dock-ng@ochi12.github.com/dockNG.js
+++ b/dock-ng@ochi12.github.com/dockNG.js
@@ -409,7 +409,7 @@ export const DockNG = GObject.registerClass({
             return;
         }
 
-        const shouldShow = block && !Main.overview.visible;
+        const shouldShow = this._blockAutoHide && !Main.overview.visible;
 
         if (shouldShow) {
             this.show(true);
@@ -418,8 +418,14 @@ export const DockNG = GObject.registerClass({
                 GLib.source_remove(this._idleHideId);
 
             this._idleHideId = GLib.idle_add(GLib.PRIORITY_DEFAULT, () => {
-                if (!this._dashContainer.get_hover())
+                // reevalute guards since we are executing it inside an idle
+                // without this guard, dock might give off a weird blink
+                // when leaving overview by picking a new window from window picker
+                if (!this._dashContainer.get_hover() &&
+                    !this._blockAutoHide &&
+                    !Main.overview.visible)
                     this.hide(true);
+
                 this._idleHideId = 0;
                 return GLib.SOURCE_REMOVE;
             });


### PR DESCRIPTION
you can now hover to dash to keep dock shown after leaving overview. Also, dock will not hide immediately when not hovered to give chance to users to cancel auto hide if needed
[Screencast From 2025-10-23 11-06-24.webm](https://github.com/user-attachments/assets/4a2bf8f9-c353-49f5-becb-ca2f742e6589)

No more unnecessary slide in animation for general overview switch:
[Screencast From 2025-10-23 11-05-28.webm](https://github.com/user-attachments/assets/73fba693-7bed-44d0-8b0e-ad444d8ab949)


closes https://github.com/ochi12/dock-ng/issues/27


Fix: dock hides when switching focus window even though mouse is hovering on the dock

closes #29